### PR TITLE
feat: post-copy feedback widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ next-env.d.ts
 /.unlighthouse/
 
 dev
+
+# feedback data
+data/feedback.json

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs/promises'
+import path from 'path'
+
+const FILE = path.join(process.cwd(), 'data', 'feedback.json')
+
+export async function POST(request: Request) {
+    try {
+        const body = await request.json()
+        const { rating, comment, timestamp } = body
+
+        if (!rating || !timestamp) {
+            return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
+        }
+
+        let entries: unknown[] = []
+        try {
+            const raw = await fs.readFile(FILE, 'utf-8')
+            entries = JSON.parse(raw)
+        } catch {
+            // file doesn't exist yet — start fresh
+        }
+
+        entries.push({ rating, comment, timestamp })
+        await fs.writeFile(FILE, JSON.stringify(entries, null, 2))
+
+        return NextResponse.json({ ok: true })
+    } catch {
+        return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+    }
+}

--- a/components/feedback/copy-feedback.tsx
+++ b/components/feedback/copy-feedback.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+
+type Stage = 'ask' | 'negative-form' | 'thanks'
+
+export function CopyFeedback({ visible, onDismiss }: { visible: boolean; onDismiss: () => void }) {
+    const [stage, setStage] = useState<Stage>('ask')
+    const [comment, setComment] = useState('')
+    const [submitting, setSubmitting] = useState(false)
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    const dismiss = useCallback(() => {
+        setStage('ask')
+        setComment('')
+        onDismiss()
+    }, [onDismiss])
+
+    const clearTimer = useCallback(() => {
+        if (timerRef.current) {
+            clearTimeout(timerRef.current)
+            timerRef.current = null
+        }
+    }, [])
+
+    // Auto-dismiss after 10s
+    useEffect(() => {
+        if (!visible) return
+        clearTimer()
+        timerRef.current = setTimeout(dismiss, 10_000)
+        return clearTimer
+    }, [visible, dismiss, clearTimer])
+
+    // Reset stage when widget becomes visible
+    useEffect(() => {
+        if (visible) {
+            setStage('ask')
+            setComment('')
+        }
+    }, [visible])
+
+    const sendFeedback = async (rating: 'positive' | 'negative', feedbackComment?: string) => {
+        try {
+            await fetch('/api/feedback', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    rating,
+                    comment: feedbackComment,
+                    timestamp: new Date().toISOString(),
+                }),
+            })
+        } catch {
+            // silently fail — feedback is non-critical
+        }
+    }
+
+    const handlePositive = () => {
+        clearTimer()
+        sendFeedback('positive')
+        setStage('thanks')
+        setTimeout(dismiss, 1500)
+    }
+
+    const handleNegative = () => {
+        clearTimer()
+        setStage('negative-form')
+        // Restart auto-dismiss with longer timeout for form
+        timerRef.current = setTimeout(dismiss, 30_000)
+    }
+
+    const handleSubmitNegative = async () => {
+        if (submitting) return
+        setSubmitting(true)
+        clearTimer()
+        await sendFeedback('negative', comment || undefined)
+        setSubmitting(false)
+        setStage('thanks')
+        setTimeout(dismiss, 1500)
+    }
+
+    return (
+        <AnimatePresence>
+            {visible && (
+                <motion.div
+                    initial={{ opacity: 0, y: 24 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: 8 }}
+                    transition={{ duration: 0.25, ease: 'easeOut' }}
+                    className='fixed bottom-4 right-4 z-50 w-72 rounded-lg border border-border bg-card p-4 shadow-lg sm:w-80'>
+                    {/* Close button */}
+                    <button
+                        onClick={dismiss}
+                        className='absolute right-2 top-2 text-muted-foreground transition-colors hover:text-foreground'
+                        aria-label='Dismiss'>
+                        <svg width='14' height='14' viewBox='0 0 14 14' fill='none'>
+                            <path
+                                d='M1 1l12 12M13 1L1 13'
+                                stroke='currentColor'
+                                strokeWidth='1.5'
+                                strokeLinecap='round'
+                            />
+                        </svg>
+                    </button>
+
+                    {stage === 'ask' && (
+                        <div className='flex flex-col items-center gap-3'>
+                            <p className='text-sm font-medium text-card-foreground'>Was this helpful?</p>
+                            <div className='flex gap-3'>
+                                <button
+                                    onClick={handlePositive}
+                                    className='rounded-md px-4 py-1.5 text-lg transition-colors hover:bg-accent'
+                                    aria-label='Helpful'>
+                                    👍
+                                </button>
+                                <button
+                                    onClick={handleNegative}
+                                    className='rounded-md px-4 py-1.5 text-lg transition-colors hover:bg-accent'
+                                    aria-label='Not helpful'>
+                                    👎
+                                </button>
+                            </div>
+                        </div>
+                    )}
+
+                    {stage === 'negative-form' && (
+                        <div className='flex flex-col gap-3'>
+                            <p className='text-sm font-medium text-card-foreground'>What could be better?</p>
+                            <textarea
+                                value={comment}
+                                onChange={(e) => setComment(e.target.value)}
+                                placeholder='Your feedback...'
+                                rows={3}
+                                className='w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring'
+                            />
+                            <button
+                                onClick={handleSubmitNegative}
+                                disabled={submitting}
+                                className='inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50'>
+                                {submitting ? 'Sending...' : 'Submit'}
+                            </button>
+                        </div>
+                    )}
+
+                    {stage === 'thanks' && (
+                        <div className='flex items-center justify-center py-1'>
+                            <p className='text-sm font-medium text-card-foreground'>
+                                {comment ? 'Thanks for the feedback!' : 'Thanks! 🎉'}
+                            </p>
+                        </div>
+                    )}
+                </motion.div>
+            )}
+        </AnimatePresence>
+    )
+}

--- a/components/tool/editor-panel.tsx
+++ b/components/tool/editor-panel.tsx
@@ -7,11 +7,13 @@ import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { toast } from 'sonner'
 
+import { CopyFeedback } from '../feedback/copy-feedback'
 import { Icons } from '../icon'
 import { Button } from '../ui/button'
 import { EditorLoading } from './editor-loading'
 import Toolbar from './toolbar'
 import { processNodes, toPlainText } from './utils'
+import { useCopyFeedback } from '@/hooks/use-copy-feedback'
 
 const listStyles = `
   .ProseMirror ul, .ProseMirror ol {
@@ -34,6 +36,7 @@ export function EditorPanel({
 }) {
     const fileInputRef = React.useRef<HTMLInputElement>(null)
     const [currentImage, setCurrentImage] = React.useState<string | null>(null)
+    const feedback = useCopyFeedback()
 
     const handleImageChangeWrapper = React.useCallback(
         (imageSrc: string | null) => {
@@ -78,9 +81,12 @@ export function EditorPanel({
 
         navigator.clipboard
             .writeText(textContent)
-            .then(() => toast.success('Text copied to clipboard'))
+            .then(() => {
+                toast.success('Text copied to clipboard')
+                feedback.show()
+            })
             .catch((err) => toast.error(`Failed to copy text: ${err}`))
-    }, [editor])
+    }, [editor, feedback])
 
     React.useEffect(() => {
         const interceptCopy = (event: ClipboardEvent) => {
@@ -230,6 +236,8 @@ export function EditorPanel({
                     </div>
                 </div>
             </div>
+
+            <CopyFeedback visible={feedback.visible} onDismiss={feedback.hide} />
         </div>
     )
 }

--- a/hooks/use-copy-feedback.ts
+++ b/hooks/use-copy-feedback.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+
+const STORAGE_KEY = 'copy-feedback-last-shown'
+const COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+export function useCopyFeedback() {
+    const [visible, setVisible] = useState(false)
+
+    const shouldShow = useCallback((): boolean => {
+        try {
+            const last = localStorage.getItem(STORAGE_KEY)
+            if (!last) return true
+            return Date.now() - Number(last) > COOLDOWN_MS
+        } catch {
+            return false
+        }
+    }, [])
+
+    const show = useCallback(() => {
+        if (!shouldShow()) return
+        try {
+            localStorage.setItem(STORAGE_KEY, String(Date.now()))
+        } catch {}
+        setVisible(true)
+    }, [shouldShow])
+
+    const hide = useCallback(() => {
+        setVisible(false)
+    }, [])
+
+    return { visible, show, hide }
+}


### PR DESCRIPTION
## Summary
- Added a micro-feedback widget that appears after the user copies their formatted LinkedIn post
- Shows "Was this helpful?" with thumbs up/down buttons in a floating card at bottom-right
- Positive feedback sends the rating and shows a brief "Thanks!" message
- Negative feedback expands a textarea for comments, then submits and dismisses
- Auto-dismisses after 10 seconds if ignored; only shows once per 7 days per user (localStorage)
- Animated with framer-motion (slide-up on appear, fade-out on dismiss)
- Feedback is stored server-side via a simple API route that appends to `data/feedback.json`

## New files
- `hooks/use-copy-feedback.ts` — state management hook with localStorage 7-day cooldown
- `components/feedback/copy-feedback.tsx` — floating feedback widget with framer-motion animations
- `app/api/feedback/route.ts` — POST endpoint that appends feedback to a JSON file

## Modified files
- `components/tool/editor-panel.tsx` — triggers the feedback widget after successful copy
- `.gitignore` — excludes `data/feedback.json` from version control

## Test plan
- [ ] Copy post text and verify the existing "Copied!" sonner toast still appears
- [ ] Verify the feedback widget slides up at bottom-right after copy
- [ ] Click thumbs up — should show "Thanks! 🎉" then auto-dismiss
- [ ] Click thumbs down — should expand textarea; submit feedback and verify dismiss
- [ ] Ignore the widget — should auto-dismiss after ~10 seconds
- [ ] Copy again immediately — widget should NOT reappear (7-day cooldown)
- [ ] Clear `copy-feedback-last-shown` from localStorage and copy — widget should appear again
- [ ] Verify `data/feedback.json` is created and contains submitted entries
- [ ] Test on mobile viewport — widget should be responsive