### PR TITLE
feat: add background AI post analysis on copy

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,0 +1,112 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { generateObject } from 'ai'
+import { z } from 'zod'
+
+import { env } from '@/env.mjs'
+import { AI_ERROR_CODES } from '@/config/ai'
+import { checkRateLimit } from '@/lib/rate-limit'
+import { createClient } from '@/lib/supabase/server'
+
+const bodySchema = z.object({
+    postText: z.string().min(1).max(10_000),
+    hasImage: z.boolean(),
+    hasFormatting: z.boolean(),
+    contentLength: z.number().int(),
+    lineCount: z.number().int(),
+    hashtagCount: z.number().int(),
+    emojiCount: z.number().int(),
+})
+
+const analysisSchema = z.object({
+    score: z.number().int().min(1).max(100),
+    hook_score: z.number().int().min(1).max(100),
+    readability_score: z.number().int().min(1).max(100),
+    cta_score: z.number().int().min(1).max(100),
+    strengths: z.array(z.string()).min(1).max(3),
+    improvements: z.array(z.string()).min(1).max(3),
+})
+
+export async function POST(request: Request) {
+    let body: unknown
+    try {
+        body = await request.json()
+    } catch {
+        return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    const parsed = bodySchema.safeParse(body)
+    if (!parsed.success) {
+        return Response.json({ error: parsed.error.issues[0]?.message ?? 'Invalid input' }, { status: 400 })
+    }
+
+    // Auth: validate the anonymous session
+    const supabase = await createClient()
+    const {
+        data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+        return Response.json({ error: 'Authentication required', code: AI_ERROR_CODES.AUTH_REQUIRED }, { status: 401 })
+    }
+
+    // Rate limit: 20 analyses per day
+    const rateLimit = await checkRateLimit(supabase, 'analysis')
+    if (!rateLimit.allowed) {
+        return Response.json(
+            { error: 'Daily analysis limit reached', code: AI_ERROR_CODES.RATE_LIMITED, resetAt: rateLimit.resetAt },
+            { status: 429 },
+        )
+    }
+
+    const openai = createOpenAI({ apiKey: env.LLM_API_KEY })
+
+    let object: z.infer<typeof analysisSchema>
+    try {
+        const result = await generateObject({
+            model: openai(env.LLM_MODEL ?? 'gpt-4o-mini'),
+            schema: analysisSchema,
+            system: `You are a LinkedIn content analyst. Evaluate posts for professional impact.
+Score each dimension 1-100. Be concise and specific.
+Consider: hook effectiveness (first line), readability (structure, sentences),
+call-to-action clarity, use of formatting/hashtags, appropriate length.
+Strengths and improvements should be 1 sentence each, referencing the actual post content.`,
+            prompt: `Analyze this LinkedIn post:
+
+Post length: ${parsed.data.contentLength} chars, ${parsed.data.lineCount} lines
+Has image: ${parsed.data.hasImage}, Has formatting: ${parsed.data.hasFormatting}
+Hashtags: ${parsed.data.hashtagCount}, Emojis: ${parsed.data.emojiCount}
+
+---
+${parsed.data.postText}
+---`,
+        })
+        object = result.object
+    } catch (err) {
+        console.error('AI analysis failed:', err)
+        return Response.json({ error: 'Failed to analyze post' }, { status: 500 })
+    }
+
+    // Store the result — fail silently if the insert fails
+    const { error: insertError } = await supabase.from('post_analyses').insert({
+        user_id: user.id,
+        post_text: parsed.data.postText,
+        content_length: parsed.data.contentLength,
+        line_count: parsed.data.lineCount,
+        hashtag_count: parsed.data.hashtagCount,
+        emoji_count: parsed.data.emojiCount,
+        has_formatting: parsed.data.hasFormatting,
+        has_image: parsed.data.hasImage,
+        score: object.score,
+        hook_score: object.hook_score,
+        readability_score: object.readability_score,
+        cta_score: object.cta_score,
+        strengths: object.strengths,
+        improvements: object.improvements,
+    })
+
+    if (insertError) {
+        console.error('Failed to store analysis:', insertError.message)
+    }
+
+    return Response.json({ success: true })
+}

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -22,8 +22,17 @@ const analysisSchema = z.object({
     hook_score: z.number().int().min(1).max(100),
     readability_score: z.number().int().min(1).max(100),
     cta_score: z.number().int().min(1).max(100),
+    engagement_score: z.number().int().min(1).max(10),
     strengths: z.array(z.string()).min(1).max(3),
     improvements: z.array(z.string()).min(1).max(3),
+    topics: z.array(z.string()).min(1).max(3),
+    sentiment: z.enum(['positive', 'neutral', 'negative']),
+    // prettier-ignore
+    category: z.enum(['thought_leadership', 'storytelling', 'educational', 'promotional', 'engagement', 'personal']),
+    tone: z.enum(['professional', 'casual', 'inspirational']),
+    has_hook: z.boolean(),
+    has_cta: z.boolean(),
+    hook_quality: z.enum(['weak', 'moderate', 'strong']),
 })
 
 export async function POST(request: Request) {
@@ -66,10 +75,20 @@ export async function POST(request: Request) {
             model: openai(env.LLM_MODEL ?? 'gpt-4o-mini'),
             schema: analysisSchema,
             system: `You are a LinkedIn content analyst. Evaluate posts for professional impact.
-Score each dimension 1-100. Be concise and specific.
-Consider: hook effectiveness (first line), readability (structure, sentences),
-call-to-action clarity, use of formatting/hashtags, appropriate length.
-Strengths and improvements should be 1 sentence each, referencing the actual post content.`,
+
+Scoring (1-100): score = overall quality, hook_score = first-line impact, readability_score = structure & clarity, cta_score = call-to-action effectiveness.
+engagement_score (1-10): predicted engagement potential.
+
+Classification:
+- topics: 1-3 short tags describing the post's subject (e.g. "leadership", "career advice", "AI")
+- sentiment: overall emotional tone (positive/neutral/negative)
+- category: primary purpose (thought_leadership/storytelling/educational/promotional/engagement/personal)
+- tone: writing style (professional/casual/inspirational)
+- has_hook: does the first line grab attention?
+- has_cta: does the post ask readers to act (comment, share, follow, click)?
+- hook_quality: weak/moderate/strong
+
+Strengths and improvements: 1 sentence each, referencing the actual post content. Be specific.`,
             prompt: `Analyze this LinkedIn post:
 
 Post length: ${parsed.data.contentLength} chars, ${parsed.data.lineCount} lines
@@ -100,8 +119,16 @@ ${parsed.data.postText}
         hook_score: object.hook_score,
         readability_score: object.readability_score,
         cta_score: object.cta_score,
+        engagement_score: object.engagement_score,
         strengths: object.strengths,
         improvements: object.improvements,
+        topics: object.topics,
+        sentiment: object.sentiment,
+        category: object.category,
+        tone: object.tone,
+        has_hook: object.has_hook,
+        has_cta: object.has_cta,
+        hook_quality: object.hook_quality,
     })
 
     if (insertError) {

--- a/config/ai.ts
+++ b/config/ai.ts
@@ -1,4 +1,4 @@
-export const AI_RATE_LIMITS = { generation: 1, refinement: 3 } as const
+export const AI_RATE_LIMITS = { generation: 1, refinement: 3, analysis: 20 } as const
 
 export const AI_ERROR_CODES = { RATE_LIMITED: 'RATE_LIMITED', AUTH_REQUIRED: 'AUTH_REQUIRED' } as const
 

--- a/config/routes.ts
+++ b/config/routes.ts
@@ -1,6 +1,7 @@
 export const ApiRoutes = {
     Chat: '/api/chat',
     Suggestions: '/api/suggestions',
+    Analyze: '/api/analyze',
 }
 
 export const Routes = {

--- a/supabase/migrations/003_post_analyses.sql
+++ b/supabase/migrations/003_post_analyses.sql
@@ -15,13 +15,22 @@ create table public.post_analyses (
     emoji_count       int not null,
     has_formatting    boolean not null default false,
     has_image         boolean not null default false,
-    -- AI-generated analysis
+    -- AI-generated scores
     score             int not null,
     hook_score        int not null,
     readability_score int not null,
     cta_score         int not null,
+    engagement_score  int not null,
     strengths         text[] not null,
     improvements      text[] not null,
+    -- AI-generated classification
+    topics            text[] not null,
+    sentiment         text not null check (sentiment in ('positive', 'neutral', 'negative')),
+    category          text not null check (category in ('thought_leadership', 'storytelling', 'educational', 'promotional', 'engagement', 'personal')),
+    tone              text not null check (tone in ('professional', 'casual', 'inspirational')),
+    has_hook          boolean not null,
+    has_cta           boolean not null,
+    hook_quality      text not null check (hook_quality in ('weak', 'moderate', 'strong')),
     created_at        timestamptz not null default now()
 );
 

--- a/supabase/migrations/003_post_analyses.sql
+++ b/supabase/migrations/003_post_analyses.sql
@@ -1,0 +1,36 @@
+-- Allow 'analysis' as a valid action in ai_usage
+alter table public.ai_usage drop constraint ai_usage_action_check;
+alter table public.ai_usage add constraint ai_usage_action_check
+    check (action in ('generation', 'refinement', 'analysis'));
+
+-- Table to store AI-powered post analysis results (analytics only)
+create table public.post_analyses (
+    id                bigint generated always as identity primary key,
+    user_id           uuid not null references auth.users(id) on delete cascade,
+    post_text         text not null,
+    -- Static metrics (passed from client)
+    content_length    int not null,
+    line_count        int not null,
+    hashtag_count     int not null,
+    emoji_count       int not null,
+    has_formatting    boolean not null default false,
+    has_image         boolean not null default false,
+    -- AI-generated analysis
+    score             int not null,
+    hook_score        int not null,
+    readability_score int not null,
+    cta_score         int not null,
+    strengths         text[] not null,
+    improvements      text[] not null,
+    created_at        timestamptz not null default now()
+);
+
+create index idx_post_analyses_user on public.post_analyses(user_id, created_at desc);
+
+alter table public.post_analyses enable row level security;
+
+create policy "Users can view own analyses" on public.post_analyses
+    for select using (auth.uid() = user_id);
+
+create policy "Service can insert analyses" on public.post_analyses
+    for insert with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- Adds `/api/analyze` route that uses `generateObject` to score LinkedIn posts (overall, hook, readability, CTA) and identify strengths/improvements
- Stores analysis results in a new `post_analyses` Supabase table with static metrics + AI scores
- Fires analysis as fire-and-forget on every copy action — no UI shown to the user
- Rate limited to 20 analyses/day per anonymous user via existing rate limit infrastructure

## Files changed
- `config/ai.ts` — added `analysis: 20` rate limit
- `config/routes.ts` — added `Analyze` API route
- `app/api/analyze/route.ts` — new API route (auth, rate limit, AI analysis, DB insert)
- `supabase/migrations/003_post_analyses.sql` — new table + updated CHECK constraint
- `components/tool/editor-panel.tsx` — wired `analyzePost` into copy flow

## Test plan
- [ ] Copy a post → verify `/api/analyze` is called (check Network tab)
- [ ] Verify analysis doesn't block or affect the copy UX (fire-and-forget)
- [ ] Verify rate limit works (20/day threshold)
- [ ] Check `post_analyses` table in Supabase for stored results
- [ ] Verify `post_analyzed` PostHog event fires on success