### PR TITLE
fix(onboarding): report the true fast_source on onb_enrich_result

### DIFF
--- a/app/api/onboarding/enrich/route.ts
+++ b/app/api/onboarding/enrich/route.ts
@@ -187,12 +187,19 @@ export async function POST(request: Request) {
           }
         : undefined
 
+    // The fast tier that actually answered: a fetched profile's own source,
+    // else 'oauth' when the OAuth-provided name/headline seeded the persona,
+    // else 'none'. Computed once so the persisted session row and the PostHog
+    // event report the same value (the event used to drop the 'oauth' branch
+    // and over-count 'none' - GH #33).
+    const fastSource = fetched?.found ? fetched.source : effName || effHeadline ? 'oauth' : 'none'
+
     // Persist the fast tier + the inference (the rich trigger was written above).
     // fast_raw keeps the COMPLETE provider payload (Scrapingdog record, or the
     // full JSON-LD extraction incl. recent post titles) for later analysis.
     const persist = async (enrichment: Record<string, unknown>) => {
         const patch: OnboardingSessionPatch = {
-            fast_source: fetched?.found ? fetched.source : effName || effHeadline ? 'oauth' : 'none',
+            fast_source: fastSource,
             fast_profile: fetched?.found
                 ? { name: fetched.name, headline: fetched.headline, about: fetched.about, avatarUrl: fetched.avatarUrl }
                 : effName || effHeadline
@@ -219,7 +226,7 @@ export async function POST(request: Request) {
             captureServer(user.id, 'onb_enrich_result', {
                 funnel_version: OB_FUNNEL_VERSION,
                 llm_ok: llmOk,
-                fast_source: fetched?.found ? fetched.source : 'none',
+                fast_source: fastSource,
                 fast_found: !!fetched?.found,
                 fast_fail_reason: fetchFailReason ?? null,
                 has_rich_signal: hasRichSignal,


### PR DESCRIPTION
Closes #33

## What the data showed
- Supabase `onboarding_drop_detail.fast_source` = `oauth` for **18 sessions** in the last 7 full days (07-16..07-22); `onb_connect_method{oauth}` fired for **33 users**.
- PostHog `onb_enrich_result.fast_source` over the same window: `none` (58 fires) and `scrapingdog` (8). **`oauth` = 0, ever** - the documented enum value is never emitted.
- Net effect: PostHog reads the fast-tier mix as near-total degradation (`none`) when ~18 of those sessions were healthy OAuth identities. The two data sources disagree by construction, which corrupts the `fast_source` mix that funnel-health and funnel-audit read.

## Root cause
`app/api/onboarding/enrich/route.ts` computed `fast_source` in two places that disagreed:
- `persist()` (session row) - three-way: `fetched?.found ? fetched.source : effName || effHeadline ? 'oauth' : 'none'`
- `reportResult()` (PostHog event) - two-way: `fetched?.found ? fetched.source : 'none'` (drops the `'oauth'` branch)

## Fix
Compute `fastSource` once, above both closures, and use it for the persisted row and the event so they can never drift.

## Verification
- `tsc --noEmit`: pass (exit 0)
- `eslint app/api/onboarding/enrich/route.ts`: pass (exit 0)
- `prettier --check`: clean
- No schema change, no new dependency, observability-only (no user-facing behaviour change).

(Ran the binaries directly: the repo's `pnpm-workspace.yaml` has no `packages:` field, which the locally-installed pnpm 11.13.1 rejects, so `pnpm type-check` / the husky pre-commit hook error out at the pnpm layer before reaching tsc/eslint. Committed with `--no-verify` for that reason.)

## Regression invariant for the next audit
`onb_enrich_result.fast_source=oauth` count should track Supabase `fast_oauth` (currently 0 vs 18). After this ships they should move together.